### PR TITLE
transpose a rotation matrix to get a coordinate transformation matrix

### DIFF
--- a/camera_models/_matrices.py
+++ b/camera_models/_matrices.py
@@ -80,6 +80,6 @@ def get_projection_matrix(
     my: float = 1.0,
 ) -> np.ndarray:
     K = get_calibration_matrix(f=f, px=px, py=py, mx=mx, my=my)
-    R = get_rotation_matrix(theta_x=theta_x, theta_y=theta_y, theta_z=theta_z)
+    R = get_rotation_matrix(theta_x=theta_x, theta_y=theta_y, theta_z=theta_z).T
     P = K @ R @ np.c_[np.eye(3), -np.asarray(C)]
     return P


### PR DESCRIPTION
The variable `R` should be a coordinate transform matrix from the world coordinate to the camera coordinate.
But `get_rotation_matrix()` returns a inverse matrix.
This PR fixes the issue by transposing (inversing) the matrix.

Ref: https://www.sciencedirect.com/topics/engineering/euler-angle
(see Eq. 9.117 - 9.120